### PR TITLE
⬆️ Update Mock Action Request to match changes from 4.24.0

### DIFF
--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -3,7 +3,9 @@
 namespace JoshGaber\NovaUnit\Actions;
 
 use JoshGaber\NovaUnit\Constraints\IsActionResponseType;
+use Laravel\Nova\Actions\ActionResponse;
 use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\Constraint\IsInstanceOf;
 use PHPUnit\Framework\Constraint\IsType;
 
 class MockActionResponse
@@ -27,8 +29,10 @@ class MockActionResponse
         PHPUnit::assertThat(
             $this->response,
             PHPUnit::logicalAnd(
-                new IsType('array'),
-                new IsActionResponseType($type)
+                is_array($this->response)
+                    ? new IsType('array')
+                    : new IsInstanceOf(ActionResponse::class),
+                new IsActionResponseType($type, $this->response)
             ),
             $message
         );
@@ -88,7 +92,18 @@ class MockActionResponse
      */
     public function assertPush(string $message = ''): self
     {
-        return $this->assertResponseType('push', $message);
+        return $this->assertResponseType('json', $message);
+    }
+
+    /**
+     * Asserts the handle response is of type "visit".
+     *
+     * @param  string  $message
+     * @return $this
+     */
+    public function assertVisit(string $message = ''): self
+    {
+        return $this->assertResponseType('visit', $message);
     }
 
     /**

--- a/src/Constraints/IsActionResponseType.php
+++ b/src/Constraints/IsActionResponseType.php
@@ -9,8 +9,9 @@ class IsActionResponseType extends Constraint
 {
     private $actionType;
 
-    public function __construct($actionType)
+    public function __construct($actionType, $actionResponse)
     {
+        $this->actionResponse = $actionResponse;
         $this->actionType = $actionType;
     }
 
@@ -24,12 +25,16 @@ class IsActionResponseType extends Constraint
 
     public function matches($response): bool
     {
-        $structure = \array_keys(\call_user_func([Action::class, $this->actionType], 'param 1', 'param 2'));
-        $responseKeys = \array_keys($response);
+        if (is_array($this->actionResponse)){
+            $structure = \array_keys(\call_user_func([Action::class, $this->actionType], 'param 1', 'param 2'));
+            $responseKeys = \array_keys($response);
 
-        \sort($structure);
-        \sort($responseKeys);
+            \sort($structure);
+            \sort($responseKeys);
 
-        return $structure === $responseKeys;
+            return $structure === $responseKeys;
+        }
+
+        return $this->actionResponse->offsetExists($this->actionType);
     }
 }

--- a/tests/Feature/Actions/MockActionResponseTest.php
+++ b/tests/Feature/Actions/MockActionResponseTest.php
@@ -60,17 +60,25 @@ class MockActionResponseTest extends TestCase
         $mockActionResponse->assertRedirect();
     }
 
-    public function testItSucceedsOnPushResponse()
-    {
-        $mockActionResponse = new MockActionResponse(Action::push('test'));
-        $mockActionResponse->assertPush();
-    }
 
     public function testItFailsOnResponseOtherThanPush()
     {
         $this->shouldFail();
         $mockActionResponse = new MockActionResponse(Action::message('test'));
         $mockActionResponse->assertPush();
+    }
+
+    public function testItSucceedsOnVisitResponse()
+    {
+        $mockActionResponse = new MockActionResponse(Action::visit('test'));
+        $mockActionResponse->assertVisit();
+    }
+
+    public function testItFailsOnResponseOtherThanVisit()
+    {
+        $this->shouldFail();
+        $mockActionResponse = new MockActionResponse(Action::message('test'));
+        $mockActionResponse->assertVisit();
     }
 
     public function testItSucceedsOnDownloadResponse()


### PR DESCRIPTION


Original Author [@kichetof](https://github.com/kichetof)

# Description

Nova 4.24.0 and up introduced a new ActionResponse class as return statement.

NovaUnit MockActionResponse expect an array instead of ActionResponse class


