### PR TITLE
⬆️ Update Mock Lens Request to match interface from 4.26.0

### DIFF
--- a/src/Lenses/MockLensRequest.php
+++ b/src/Lenses/MockLensRequest.php
@@ -24,7 +24,7 @@ class MockLensRequest extends LensRequest
         return $query;
     }
 
-    public function withOrdering($query)
+    public function withOrdering($query, $defaultCallback = null)
     {
         $this->withOrdering = true;
 


### PR DESCRIPTION
# Description

Nova 4.26.0 changed the interface for Lens Requests causing a breaking change.

# Implementation

1. Update interface for MockLensRequest to match the interface in Nova.


