### PR TITLE
✨Feature: Add accessor to get Fields from MockAction and Response from MockActionResponse

### DIFF
--- a/src/Actions/MockAction.php
+++ b/src/Actions/MockAction.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use JoshGaber\NovaUnit\MockComponent;
 use JoshGaber\NovaUnit\Traits\FieldAssertions;
 use Laravel\Nova\Fields\ActionFields;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class MockAction extends MockComponent
 {
@@ -28,5 +29,10 @@ class MockAction extends MockComponent
                 $models instanceof Collection ? $models : collect(Arr::wrap($models))
             )
         );
+    }
+
+    public function getFields(NovaRequest $request = null): array
+    {
+        return $this->component->fields($request ?? NovaRequest::createFromGlobals());
     }
 }

--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -165,4 +165,12 @@ class MockActionResponse
     {
         return $this->assertResponseContains($contents, 'danger', $message);
     }
+
+    /**
+     * @return array|ActionResponse|null
+     */
+    public function getResponse(): array|ActionResponse|null
+    {
+        return $this->response;
+    }
 }

--- a/tests/Feature/Actions/MockActionResponseTest.php
+++ b/tests/Feature/Actions/MockActionResponseTest.php
@@ -5,6 +5,7 @@ namespace JoshGaber\NovaUnit\Tests\Feature\Actions;
 use JoshGaber\NovaUnit\Actions\MockActionResponse;
 use JoshGaber\NovaUnit\Tests\TestCase;
 use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Actions\ActionResponse;
 
 class MockActionResponseTest extends TestCase
 {
@@ -151,5 +152,11 @@ class MockActionResponseTest extends TestCase
         $this->shouldFail();
         $mockActionResponse = new MockActionResponse();
         $mockActionResponse->assertResponseType('message');
+    }
+
+    public function testItCanGetResponse()
+    {
+        $mockActionResponse = new MockActionResponse(Action::message('Test Message'));
+        $this->assertInstanceOf(ActionResponse::class, $mockActionResponse->getResponse());
     }
 }

--- a/tests/Feature/Actions/MockActionTest.php
+++ b/tests/Feature/Actions/MockActionTest.php
@@ -25,8 +25,5 @@ class MockActionTest extends TestCase
         $this->assertIsArray($mockAction->getFields());
 
         $this->assertIsArray($mockAction->getFields(NovaRequest::createFromGlobals()));
-
     }
-
-
 }

--- a/tests/Feature/Actions/MockActionTest.php
+++ b/tests/Feature/Actions/MockActionTest.php
@@ -6,6 +6,7 @@ use JoshGaber\NovaUnit\Actions\MockAction;
 use JoshGaber\NovaUnit\Actions\MockActionResponse;
 use JoshGaber\NovaUnit\Tests\Fixtures\Actions\ActionValidFields;
 use JoshGaber\NovaUnit\Tests\TestCase;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class MockActionTest extends TestCase
 {
@@ -16,4 +17,16 @@ class MockActionTest extends TestCase
 
         $this->assertInstanceOf(MockActionResponse::class, $mockResult);
     }
+
+    public function testItReturnsMockActionFields()
+    {
+        $mockAction = new MockAction(new ActionValidFields());
+
+        $this->assertIsArray($mockAction->getFields());
+
+        $this->assertIsArray($mockAction->getFields(NovaRequest::createFromGlobals()));
+
+    }
+
+
 }


### PR DESCRIPTION
Closes #9 
Closes #3 

# Description

Provides additional accessors to MockAction classes.

# Implementation

1. Add getter to `MockAction` to expose `fields`
2. Add getter to `MockActionResponse` to expose `response`

