### PR TITLE
🔨 Remove version from composer.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,11 @@ name: Linting and Tests
 
 on:
     pull_request:
-        branches: [main, release/*]
         paths-ignore:
             - "**/*.md"
             - "*.md"
             - "**/*.json"
-    push:
-        branches: [main]
+
 
 jobs:
     laravel-tests:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "quotevelocity/novaunit",
     "description": "Unit testing suite for Laravel Nova, built to extend PHPUnit",
-    "version": "4.0.0",
     "keywords": [
         "laravel",
         "nova",


### PR DESCRIPTION
Removes version from composer.json in favor of tags managed by github for packagist.