### PR TITLE
✨ Add ability to assert Visit Path

### DIFF
--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -98,12 +98,17 @@ class MockActionResponse
     /**
      * Asserts the handle response is of type "visit".
      *
-     * @param  string  $message
+     * @param string|null $path
+     * @param array $options
      * @return $this
      */
-    public function assertVisit(string $message = ''): self
+    public function assertVisit(string $path = '', array $options = []): self
     {
-        return $this->assertResponseType('visit', $message);
+        if (blank($path)) {
+            return $this->assertResponseType('visit');
+        }
+
+        return $this->assertResponseContainsArray([ 'path' => $path, 'options' => $options ], 'visit');
     }
 
     /**
@@ -135,6 +140,20 @@ class MockActionResponse
             PHPUnit::logicalAnd(
                 PHPUnit::logicalNot(PHPUnit::isEmpty()),
                 PHPUnit::stringContains($contents, true)
+            ),
+            $message
+        );
+
+        return $this;
+    }
+
+    private function assertResponseContainsArray(array $contents, string $type, string $message = ''): self
+    {
+        PHPUnit::assertThat(
+            $this->response[ $type ] ?? '',
+            PHPUnit::logicalAnd(
+                PHPUnit::logicalNot(PHPUnit::isEmpty()),
+                PHPUnit::equalTo($contents)
             ),
             $message
         );

--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -108,7 +108,7 @@ class MockActionResponse
             return $this->assertResponseType('visit');
         }
 
-        return $this->assertResponseContainsArray([ 'path' => $path, 'options' => $options ], 'visit');
+        return $this->assertResponseContainsArray([ 'path' => $path, 'options' => array_values($options) ], 'visit');
     }
 
     /**

--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -108,7 +108,7 @@ class MockActionResponse
             return $this->assertResponseType('visit');
         }
 
-        return $this->assertResponseContainsArray([ 'path' => $path, 'options' => array_values($options) ], 'visit');
+        return $this->assertResponseContainsArray(['path' => $path, 'options' => array_values($options)], 'visit');
     }
 
     /**
@@ -150,7 +150,7 @@ class MockActionResponse
     private function assertResponseContainsArray(array $contents, string $type, string $message = ''): self
     {
         PHPUnit::assertThat(
-            $this->response[ $type ] ?? '',
+            $this->response[$type] ?? '',
             PHPUnit::logicalAnd(
                 PHPUnit::logicalNot(PHPUnit::isEmpty()),
                 PHPUnit::equalTo($contents)

--- a/tests/Feature/Actions/MockActionResponseTest.php
+++ b/tests/Feature/Actions/MockActionResponseTest.php
@@ -74,11 +74,24 @@ class MockActionResponseTest extends TestCase
         $mockActionResponse->assertVisit();
     }
 
+    public function testItSucceedsOnVisitResponseWithPath()
+    {
+        $mockActionResponse = new MockActionResponse(Action::visit('/test/path'));
+        $mockActionResponse->assertVisit('/test/path');
+    }
+
     public function testItFailsOnResponseOtherThanVisit()
     {
         $this->shouldFail();
         $mockActionResponse = new MockActionResponse(Action::message('test'));
         $mockActionResponse->assertVisit();
+    }
+
+    public function testItFailsOnVisitResponseWithPathIncorrect()
+    {
+        $this->shouldFail();
+        $mockActionResponse = new MockActionResponse(Action::visit('/test/path'));
+        $mockActionResponse->assertVisit('/test/wrongpath');
     }
 
     public function testItSucceedsOnDownloadResponse()


### PR DESCRIPTION
Extends `$mockActionResponse->assertVisit()` to allow an optional path to be asserted.

e.g.

```php

        $action = $this->novaAction(SomeVisitAction::class);
        $response = $action->handle();
        $response->assertVisit('http/path');
```