### PR TITLE
Add phpunit 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: Linting and Tests
 
 on:
     pull_request:
-        branches: [main, release/*, add-phpunit-12-support]
+        branches: [main, release/*]
         paths-ignore:
             - "**/*.md"
             - "*.md"
             - "**/*.json"
     push:
-        branches: [main, add-phpunit-12-support]
+        branches: [main]
 
 jobs:
     laravel-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: Linting and Tests
 
 on:
     pull_request:
-        branches: [main, release/*]
+        branches: [main, release/*, add-phpunit-12-support]
         paths-ignore:
             - "**/*.md"
             - "*.md"
             - "**/*.json"
     push:
-        branches: [main]
+        branches: [main, add-phpunit-12-support]
 
 jobs:
     laravel-tests:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/support": "^10.34|^11.0|^12.0",
         "illuminate/testing": "^10.34|^11.0|^12.0",
         "laravel/nova": "^5.0",
-        "phpunit/phpunit": "^10.0|^11.0"
+        "phpunit/phpunit": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/src/Traits/ActionAssertions.php
+++ b/src/Traits/ActionAssertions.php
@@ -10,6 +10,7 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
+use PHPUnit\Framework\NativeType;
 
 trait ActionAssertions
 {
@@ -73,8 +74,8 @@ trait ActionAssertions
         PHPUnit::assertThat(
             $this->component->actions(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
-                new IsType(IsType::TYPE_ARRAY),
-                new TraversableContainsOnly(Action::class, false)
+                new IsType(NativeType::Array),
+                TraversableContainsOnly::forClassOrInterface(Action::class)
             ),
             $message
         );

--- a/src/Traits/ActionAssertions.php
+++ b/src/Traits/ActionAssertions.php
@@ -8,8 +8,8 @@ use JoshGaber\NovaUnit\Constraints\ArrayHasInstanceOf;
 use Laravel\Nova\Actions\Action;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
-use function PHPUnit\Framework\isArray;
 
 trait ActionAssertions
 {
@@ -73,8 +73,12 @@ trait ActionAssertions
         PHPUnit::assertThat(
             $this->component->actions(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
-                isArray(),
-                TraversableContainsOnly::forClassOrInterface(Action::class)
+                function_exists('\PHPUnit\Framework\isArray')
+                    ? \PHPUnit\Framework\isArray()
+                    : new IsType(constant('PHPUnit\Framework\Constraint\IsType::TYPE_ARRAY') ?? 'array'),
+                method_exists(\PHPUnit\Framework\Constraint\TraversableContainsOnly::class, 'forClassOrInterface')
+                    ? TraversableContainsOnly::forClassOrInterface(Action::class)
+                    : new TraversableContainsOnly(Action::class, false)
             ),
             $message
         );

--- a/src/Traits/ActionAssertions.php
+++ b/src/Traits/ActionAssertions.php
@@ -76,7 +76,7 @@ trait ActionAssertions
                 function_exists('\PHPUnit\Framework\isArray')
                     ? \PHPUnit\Framework\isArray()
                     : new IsType(constant('PHPUnit\Framework\Constraint\IsType::TYPE_ARRAY') ?? 'array'),
-                method_exists(\PHPUnit\Framework\Constraint\TraversableContainsOnly::class, 'forClassOrInterface')
+                method_exists(TraversableContainsOnly::class, 'forClassOrInterface')
                     ? TraversableContainsOnly::forClassOrInterface(Action::class)
                     : new TraversableContainsOnly(Action::class, false)
             ),

--- a/src/Traits/ActionAssertions.php
+++ b/src/Traits/ActionAssertions.php
@@ -8,9 +8,8 @@ use JoshGaber\NovaUnit\Constraints\ArrayHasInstanceOf;
 use Laravel\Nova\Actions\Action;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
-use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
-use PHPUnit\Framework\NativeType;
+use function PHPUnit\Framework\isArray;
 
 trait ActionAssertions
 {
@@ -74,7 +73,7 @@ trait ActionAssertions
         PHPUnit::assertThat(
             $this->component->actions(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
-                new IsType(NativeType::Array),
+                isArray(),
                 TraversableContainsOnly::forClassOrInterface(Action::class)
             ),
             $message

--- a/src/Traits/FieldAssertions.php
+++ b/src/Traits/FieldAssertions.php
@@ -12,6 +12,7 @@ use JoshGaber\NovaUnit\Resources\MockResource;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Framework\NativeType;
 
 trait FieldAssertions
 {
@@ -76,7 +77,7 @@ trait FieldAssertions
         PHPUnit::assertThat(
             $this->component->fields(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
-                new IsType(IsType::TYPE_ARRAY),
+                new IsType(NativeType::Array),
                 new HasValidFields($this->allowPanels())
             ),
             $message

--- a/src/Traits/FieldAssertions.php
+++ b/src/Traits/FieldAssertions.php
@@ -11,7 +11,7 @@ use JoshGaber\NovaUnit\Lenses\MockLens;
 use JoshGaber\NovaUnit\Resources\MockResource;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
-use function PHPUnit\Framework\isArray;
+use PHPUnit\Framework\Constraint\IsType;
 
 trait FieldAssertions
 {
@@ -76,7 +76,9 @@ trait FieldAssertions
         PHPUnit::assertThat(
             $this->component->fields(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
-                isArray(),
+                function_exists('\PHPUnit\Framework\isArray')
+                    ? \PHPUnit\Framework\isArray()
+                    : new IsType(constant('PHPUnit\Framework\Constraint\IsType::TYPE_ARRAY') ?? 'array'),
                 new HasValidFields($this->allowPanels())
             ),
             $message

--- a/src/Traits/FieldAssertions.php
+++ b/src/Traits/FieldAssertions.php
@@ -11,8 +11,7 @@ use JoshGaber\NovaUnit\Lenses\MockLens;
 use JoshGaber\NovaUnit\Resources\MockResource;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
-use PHPUnit\Framework\Constraint\IsType;
-use PHPUnit\Framework\NativeType;
+use function PHPUnit\Framework\isArray;
 
 trait FieldAssertions
 {
@@ -77,7 +76,7 @@ trait FieldAssertions
         PHPUnit::assertThat(
             $this->component->fields(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
-                new IsType(NativeType::Array),
+                isArray(),
                 new HasValidFields($this->allowPanels())
             ),
             $message

--- a/src/Traits/FilterAssertions.php
+++ b/src/Traits/FilterAssertions.php
@@ -8,6 +8,7 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
+use PHPUnit\Framework\NativeType;
 
 trait FilterAssertions
 {
@@ -71,8 +72,8 @@ trait FilterAssertions
         PHPUnit::assertThat(
             $this->component->filters(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
-                new IsType(IsType::TYPE_ARRAY),
-                new TraversableContainsOnly(Filter::class, false)
+                new IsType(NativeType::Array),
+                TraversableContainsOnly::forClassOrInterface(Filter::class)
             ),
             $message
         );

--- a/src/Traits/FilterAssertions.php
+++ b/src/Traits/FilterAssertions.php
@@ -74,7 +74,7 @@ trait FilterAssertions
                 function_exists('\PHPUnit\Framework\isArray')
                     ? \PHPUnit\Framework\isArray()
                     : new IsType(constant('PHPUnit\Framework\Constraint\IsType::TYPE_ARRAY') ?? 'array'),
-                method_exists(\PHPUnit\Framework\Constraint\TraversableContainsOnly::class, 'forClassOrInterface')
+                method_exists(TraversableContainsOnly::class, 'forClassOrInterface')
                     ? TraversableContainsOnly::forClassOrInterface(Filter::class)
                     : new TraversableContainsOnly(Filter::class, false)
             ),

--- a/src/Traits/FilterAssertions.php
+++ b/src/Traits/FilterAssertions.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
 use PHPUnit\Framework\NativeType;
+use function PHPUnit\Framework\isArray;
 
 trait FilterAssertions
 {
@@ -72,7 +73,7 @@ trait FilterAssertions
         PHPUnit::assertThat(
             $this->component->filters(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
-                new IsType(NativeType::Array),
+                isArray(),
                 TraversableContainsOnly::forClassOrInterface(Filter::class)
             ),
             $message

--- a/src/Traits/FilterAssertions.php
+++ b/src/Traits/FilterAssertions.php
@@ -8,8 +8,6 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
-use PHPUnit\Framework\NativeType;
-use function PHPUnit\Framework\isArray;
 
 trait FilterAssertions
 {
@@ -73,8 +71,12 @@ trait FilterAssertions
         PHPUnit::assertThat(
             $this->component->filters(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
-                isArray(),
-                TraversableContainsOnly::forClassOrInterface(Filter::class)
+                function_exists('\PHPUnit\Framework\isArray')
+                    ? \PHPUnit\Framework\isArray()
+                    : new IsType(constant('PHPUnit\Framework\Constraint\IsType::TYPE_ARRAY') ?? 'array'),
+                method_exists(\PHPUnit\Framework\Constraint\TraversableContainsOnly::class, 'forClassOrInterface')
+                    ? TraversableContainsOnly::forClassOrInterface(Filter::class)
+                    : new TraversableContainsOnly(Filter::class, false)
             ),
             $message
         );


### PR DESCRIPTION
#8 

# Description

So `IsType::TYPE_ARRAY` doesn't exist in PHPUnit 12, which causes most of the errors with simply adding PHPUnit 12 as supported in `composer.json`.
The [correct way](https://github.com/sebastianbergmann/phpunit/blob/11.5/DEPRECATIONS.md#deprecations) to fix this is using isArray() introduced in PHPUnit 11.
However, that doesn't exist in PHPUnit 10, which means we drop support for Laravel 10.

Another way I tried to fix this is to keep the `new IsType()` with `NativeType::Array`, but that also doesn't exist in earlier versions.

In the end, this is the way I went with, but it still has caveats (this example is from `FilterAssertions.php`):

```php
PHPUnit::assertThat(
    $this->component->filters(NovaRequest::createFromGlobals()),
    PHPUnit::logicalAnd(
        function_exists('\PHPUnit\Framework\isArray')
            ? \PHPUnit\Framework\isArray()
            : new IsType(constant('PHPUnit\Framework\Constraint\IsType::TYPE_ARRAY') ?? 'array'),
        method_exists(TraversableContainsOnly::class, 'forClassOrInterface')
            ? TraversableContainsOnly::forClassOrInterface(Filter::class)
            : new TraversableContainsOnly(Filter::class, false)
    ),
    $message
);
```

I have created a fork of this repo and implemented this... gory fix. It passes the tests (finally), but undoubtedly there's a more beautiful / better way to do this that I just simply don't see at the moment.
Maybe someone with fresh eyes can chime in here!

# Testing

I have tested this only using the Github Actions workflow by temporarily allowing my branch to be picked up by GH Actions. I've reverted that part of this PR.
