### PR TITLE
Enhance `FieldAssertions` fields resolve, add batch [Has|Missing]Fields, add NovaRequest and resource has parameters + fix deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
             - "*.md"
             - "**/*.json"
     push:
-        branches: [main]
+        branches: [main, enhancements]
 
 jobs:
     laravel-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: Linting and Tests
 
 on:
     pull_request:
-        branches: [main, release/*, enhancements]
+        branches: [main, release/*]
         paths-ignore:
             - "**/*.md"
             - "*.md"
             - "**/*.json"
     push:
-        branches: [main, enhancements]
+        branches: [main]
 
 jobs:
     laravel-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Linting and Tests
 
 on:
     pull_request:
-        branches: [main, release/*]
+        branches: [main, release/*, enhancements]
         paths-ignore:
             - "**/*.md"
             - "*.md"

--- a/src/Actions/MockAction.php
+++ b/src/Actions/MockAction.php
@@ -31,7 +31,7 @@ class MockAction extends MockComponent
         );
     }
 
-    public function getFields(NovaRequest $request = null): array
+    public function getFields(?NovaRequest $request = null): array
     {
         return $this->component->fields($request ?? NovaRequest::createFromGlobals());
     }

--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -2,6 +2,7 @@
 
 namespace JoshGaber\NovaUnit\Actions;
 
+use Composer\InstalledVersions;
 use Illuminate\Testing\Constraints\ArraySubset;
 use JoshGaber\NovaUnit\Constraints\IsActionResponseType;
 use Laravel\Nova\Actions\ActionResponse;
@@ -10,6 +11,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\IsInstanceOf;
 use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Framework\NativeType;
 
 class MockActionResponse
 {
@@ -29,11 +31,16 @@ class MockActionResponse
      */
     public function assertResponseType(string $type, string $message = ''): self
     {
+        $phpunitVersion = InstalledVersions::getVersion('phpunit/phpunit');
+        $constraint = version_compare($phpunitVersion, '12.0.0', '<')
+            ? new IsType(IsType::TYPE_ARRAY)
+            : new IsType(NativeType::Array);
+
         PHPUnit::assertThat(
             $this->response,
             PHPUnit::logicalAnd(
                 is_array($this->response)
-                    ? new IsType('array')
+                    ? $constraint
                     : new IsInstanceOf(ActionResponse::class),
                 new IsActionResponseType($type, $this->response)
             ),

--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -2,7 +2,6 @@
 
 namespace JoshGaber\NovaUnit\Actions;
 
-use Composer\InstalledVersions;
 use Illuminate\Testing\Constraints\ArraySubset;
 use JoshGaber\NovaUnit\Constraints\IsActionResponseType;
 use Laravel\Nova\Actions\ActionResponse;
@@ -10,8 +9,6 @@ use Laravel\Nova\Actions\Responses\Visit;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\IsInstanceOf;
-use PHPUnit\Framework\Constraint\IsType;
-use PHPUnit\Framework\NativeType;
 
 class MockActionResponse
 {
@@ -31,17 +28,10 @@ class MockActionResponse
      */
     public function assertResponseType(string $type, string $message = ''): self
     {
-        $phpunitVersion = InstalledVersions::getVersion('phpunit/phpunit');
-        $constraint = version_compare($phpunitVersion, '12.0.0', '<')
-            ? new IsType(IsType::TYPE_ARRAY)
-            : new IsType(NativeType::Array);
-
         PHPUnit::assertThat(
             $this->response,
             PHPUnit::logicalAnd(
-                is_array($this->response)
-                    ? $constraint
-                    : new IsInstanceOf(ActionResponse::class),
+                new IsInstanceOf(ActionResponse::class),
                 new IsActionResponseType($type, $this->response)
             ),
             $message

--- a/src/Constraints/IsActionResponseType.php
+++ b/src/Constraints/IsActionResponseType.php
@@ -2,7 +2,6 @@
 
 namespace JoshGaber\NovaUnit\Constraints;
 
-use Laravel\Nova\Actions\Action;
 use PHPUnit\Framework\Constraint\Constraint;
 
 class IsActionResponseType extends Constraint
@@ -26,16 +25,6 @@ class IsActionResponseType extends Constraint
 
     public function matches($response): bool
     {
-        if (is_array($this->actionResponse)) {
-            $structure = \array_keys(\call_user_func([Action::class, $this->actionType], 'param 1', 'param 2'));
-            $responseKeys = \array_keys($response);
-
-            \sort($structure);
-            \sort($responseKeys);
-
-            return $structure === $responseKeys;
-        }
-
         return $this->actionResponse->offsetExists($this->actionType);
     }
 }

--- a/src/Constraints/IsActionResponseType.php
+++ b/src/Constraints/IsActionResponseType.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 
 class IsActionResponseType extends Constraint
 {
+    private $actionResponse;
     private $actionType;
 
     public function __construct($actionType, $actionResponse)

--- a/src/Fields/MockFieldElement.php
+++ b/src/Fields/MockFieldElement.php
@@ -3,6 +3,7 @@
 namespace JoshGaber\NovaUnit\Fields;
 
 use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MockFieldElement
@@ -106,13 +107,15 @@ class MockFieldElement
      * Assert that the field can be shown on the index view.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Nova\Support\Fluent|object|array $resource
      * @return $this
      */
-    public function assertShownOnIndex(string $message = ''): self
+    public function assertShownOnIndex(string $message = '', ?NovaRequest $request = null, mixed $resource = []): self
     {
         $test = $this->field->showOnIndex;
         PHPUnit::assertTrue(
-            is_callable($test) ? $test() : $test,
+            is_callable($test) ? $test($request ?? NovaRequest::createFromGlobals(), $resource) : $test,
             $message
         );
 
@@ -123,13 +126,15 @@ class MockFieldElement
      * Assert that the field is hidden from the index view.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Nova\Support\Fluent|object|array $resource
      * @return $this
      */
-    public function assertHiddenFromIndex(string $message = ''): self
+    public function assertHiddenFromIndex(string $message = '', ?NovaRequest $request = null, mixed $resource = []): self
     {
         $test = $this->field->showOnIndex;
         PHPUnit::assertFalse(
-            is_callable($test) ? $test() : $test,
+            is_callable($test) ? $test($request ?? NovaRequest::createFromGlobals(), $resource) : $test,
             $message
         );
 
@@ -140,13 +145,15 @@ class MockFieldElement
      * Assert that the field can be shown on the detail view.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Nova\Support\Fluent|object|array $resource
      * @return $this
      */
-    public function assertShownOnDetail(string $message = ''): self
+    public function assertShownOnDetail(string $message = '', ?NovaRequest $request = null, mixed $resource = []): self
     {
         $test = $this->field->showOnDetail;
         PHPUnit::assertTrue(
-            is_callable($test) ? $test() : $test,
+            is_callable($test) ? $test($request ?? NovaRequest::createFromGlobals(), $resource) : $test,
             $message
         );
 
@@ -157,13 +164,15 @@ class MockFieldElement
      * Assert that the field is hidden from the detail view.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Nova\Support\Fluent|object|array $resource
      * @return $this
      */
-    public function assertHiddenFromDetail(string $message = ''): self
+    public function assertHiddenFromDetail(string $message = '', ?NovaRequest $request = null, mixed $resource = []): self
     {
         $test = $this->field->showOnDetail;
         PHPUnit::assertFalse(
-            is_callable($test) ? $test() : $test,
+            is_callable($test) ? $test($request ?? NovaRequest::createFromGlobals(), $resource) : $test,
             $message
         );
 
@@ -174,13 +183,15 @@ class MockFieldElement
      * Assert that the field can be shown when creating a new record.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Nova\Support\Fluent|object|array $resource
      * @return $this
      */
-    public function assertShownWhenCreating(string $message = ''): self
+    public function assertShownWhenCreating(string $message = '', ?NovaRequest $request = null, mixed $resource = []): self
     {
         $test = $this->field->showOnCreation;
         PHPUnit::assertTrue(
-            is_callable($test) ? $test() : $test,
+            is_callable($test) ? $test($request ?? NovaRequest::createFromGlobals(), $resource) : $test,
             $message
         );
 
@@ -191,13 +202,15 @@ class MockFieldElement
      * Assert that the field is hidden when creating a new record.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Nova\Support\Fluent|object|array $resource
      * @return $this
      */
-    public function assertHiddenWhenCreating(string $message = ''): self
+    public function assertHiddenWhenCreating(string $message = '', ?NovaRequest $request = null, mixed $resource = []): self
     {
         $test = $this->field->showOnCreation;
         PHPUnit::assertFalse(
-            is_callable($test) ? $test() : $test,
+            is_callable($test) ? $test($request ?? NovaRequest::createFromGlobals(), $resource) : $test,
             $message
         );
 
@@ -208,13 +221,15 @@ class MockFieldElement
      * Assert that the field can be shown when updating a record.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Nova\Support\Fluent|object|array $resource
      * @return $this
      */
-    public function assertShownWhenUpdating(string $message = ''): self
+    public function assertShownWhenUpdating(string $message = '', ?NovaRequest $request = null, mixed $resource = []): self
     {
         $test = $this->field->showOnUpdate;
         PHPUnit::assertTrue(
-            is_callable($test) ? $test() : $test,
+            is_callable($test) ? $test($request ?? NovaRequest::createFromGlobals(), $resource) : $test,
             $message
         );
 
@@ -225,13 +240,15 @@ class MockFieldElement
      * Assert that the field is hidden when updating a record.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
+     * @param  \Illuminate\Database\Eloquent\Model|\Laravel\Nova\Support\Fluent|object|array $resource
      * @return $this
      */
-    public function assertHiddenWhenUpdating(string $message = ''): self
+    public function assertHiddenWhenUpdating(string $message = '', ?NovaRequest $request = null, mixed $resource = []): self
     {
         $test = $this->field->showOnUpdate;
         PHPUnit::assertFalse(
-            is_callable($test) ? $test() : $test,
+            is_callable($test) ? $test($request ?? NovaRequest::createFromGlobals(), $resource) : $test,
             $message
         );
 

--- a/src/Traits/FieldAssertions.php
+++ b/src/Traits/FieldAssertions.php
@@ -3,6 +3,7 @@
 namespace JoshGaber\NovaUnit\Traits;
 
 use JoshGaber\NovaUnit\Constraints\HasField;
+use Illuminate\Support\Arr;
 use JoshGaber\NovaUnit\Constraints\HasValidFields;
 use JoshGaber\NovaUnit\Fields\FieldHelper;
 use JoshGaber\NovaUnit\Fields\FieldNotFoundException;
@@ -20,15 +21,33 @@ trait FieldAssertions
      *
      * @param  string  $field  The name or attribute of the field
      * @param  string  $message
+     * @param  NovaRequest|null $request
      * @return $this
      */
-    public function assertHasField(string $field, string $message = ''): self
+    public function assertHasField(string $field, string $message = '', ?NovaRequest $request = null): self
     {
         PHPUnit::assertThat(
-            $this->component->fields(NovaRequest::createFromGlobals()),
+            $this->fieldsForComponent($request),
             new HasField($field, $this->allowPanels()),
             $message
         );
+
+        return $this;
+    }
+
+    /**
+     * Checks that this Nova component has all the fields with the same name or attribute.
+     *
+     * @param  string[]  $fields
+     * @param  string  $message
+     * @param  NovaRequest|null  $request
+     * @return $this
+     */
+    public function assertHasFields(array $fields, string $message = '', ?NovaRequest $request = null): self
+    {
+        foreach ($fields as $field) {
+            $this->assertHasField($field, $message, $request);
+        }
 
         return $this;
     }
@@ -41,10 +60,10 @@ trait FieldAssertions
      * @param  string  $message
      * @return $this
      */
-    public function assertFieldMissing(string $field, string $message = ''): self
+    public function assertFieldMissing(string $field, string $message = '', ?NovaRequest $request = null): self
     {
         PHPUnit::assertThat(
-            $this->component->fields(NovaRequest::createFromGlobals()),
+            $this->fieldsForComponent($request),
             PHPUnit::logicalNot(new HasField($field, $this->allowPanels())),
             $message
         );
@@ -53,14 +72,33 @@ trait FieldAssertions
     }
 
     /**
+     * Checks that no fields on this Nova component has a name or attribute matching
+     * the given parameter.
+     *
+     * @param  string[]  $fields
+     * @param  string  $message
+     * @param  NovaRequest|null  $request
+     * @return $this
+     */
+    public function assertFieldsMissing(array $fields, string $message = '', ?NovaRequest $request = null): self
+    {
+        foreach ($fields as $field) {
+            $this->assertFieldMissing($field, $message, $request);
+        }
+
+        return $this;
+    }
+
+    /**
      * Asserts that this Nova Action has no fields defined.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
      * @return $this
      */
-    public function assertHasNoFields(string $message = ''): self
+    public function assertHasNoFields(string $message = '', ?NovaRequest $request = null): self
     {
-        PHPUnit::assertCount(0, $this->component->fields(NovaRequest::createFromGlobals()), $message);
+        PHPUnit::assertCount(0, $this->fieldsForComponent($request), $message);
 
         return $this;
     }
@@ -69,12 +107,13 @@ trait FieldAssertions
      * Asserts that all fields defined on this Nova Action are valid fields.
      *
      * @param  string  $message
+     * @param  NovaRequest|null $request
      * @return $this
      */
-    public function assertHasValidFields(string $message = ''): self
+    public function assertHasValidFields(string $message = '', ?NovaRequest $request = null): self
     {
         PHPUnit::assertThat(
-            $this->component->fields(NovaRequest::createFromGlobals()),
+            $this->fieldsForComponent($request),
             PHPUnit::logicalAnd(
                 function_exists('\PHPUnit\Framework\isArray')
                     ? \PHPUnit\Framework\isArray()
@@ -91,14 +130,15 @@ trait FieldAssertions
      * Searches for a matching field instance on this component for testing.
      *
      * @param  string  $fieldName  The name or attribute of the field to return
+     * @param  NovaRequest|null $request
      * @return MockFieldElement
      *
      * @throws FieldNotFoundException
      */
-    public function field(string $fieldName): MockFieldElement
+    public function field(string $fieldName, ?NovaRequest $request = null): MockFieldElement
     {
         $field = FieldHelper::findField(
-            $this->component->fields(NovaRequest::createFromGlobals()),
+            $this->fieldsForComponent($request),
             $fieldName,
             $this->allowPanels()
         );
@@ -113,5 +153,27 @@ trait FieldAssertions
     private function allowPanels(): bool
     {
         return $this instanceof MockLens || $this instanceof MockResource;
+    }
+
+    /**
+     * Get the fields defined on this component.
+     *
+     * @param  NovaRequest|null  $request
+     * @return array<int, \Laravel\Nova\Fields\Field>
+     */
+    private function fieldsForComponent(?NovaRequest $request = null): array
+    {
+        $request ??= NovaRequest::createFromGlobals();
+
+        /*
+         * Nova Resource uses the ConditionallyLoadsAttributes trait which requires filtering out MergeValue and
+         * MissingValue instances. To do this, we use the `availableFields` method when it's defined on the component.
+         * If not available (like in `Action` classes), we fall back to the standard `fields` method.
+         */
+        return Arr::wrap(
+            method_exists($this->component, 'availableFields')
+                ? $this->component->availableFields($request)->all()
+                : $this->component->fields($request)
+        );
     }
 }

--- a/src/Traits/FieldAssertions.php
+++ b/src/Traits/FieldAssertions.php
@@ -2,8 +2,8 @@
 
 namespace JoshGaber\NovaUnit\Traits;
 
-use JoshGaber\NovaUnit\Constraints\HasField;
 use Illuminate\Support\Arr;
+use JoshGaber\NovaUnit\Constraints\HasField;
 use JoshGaber\NovaUnit\Constraints\HasValidFields;
 use JoshGaber\NovaUnit\Fields\FieldHelper;
 use JoshGaber\NovaUnit\Fields\FieldNotFoundException;

--- a/tests/Feature/Fields/MockFieldElementTest.php
+++ b/tests/Feature/Fields/MockFieldElementTest.php
@@ -7,7 +7,6 @@ use JoshGaber\NovaUnit\Tests\Fixtures\MockModel;
 use JoshGaber\NovaUnit\Tests\Fixtures\Resources\ResourceForFieldTests;
 use JoshGaber\NovaUnit\Tests\TestCase;
 use Laravel\Nova\Http\Requests\LensRequest;
-use Laravel\Nova\Http\Requests\NovaRequest;
 
 class MockFieldElementTest extends TestCase
 {

--- a/tests/Feature/Fields/MockFieldElementTest.php
+++ b/tests/Feature/Fields/MockFieldElementTest.php
@@ -6,6 +6,8 @@ use JoshGaber\NovaUnit\Resources\MockResource;
 use JoshGaber\NovaUnit\Tests\Fixtures\MockModel;
 use JoshGaber\NovaUnit\Tests\Fixtures\Resources\ResourceForFieldTests;
 use JoshGaber\NovaUnit\Tests\TestCase;
+use Laravel\Nova\Http\Requests\LensRequest;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class MockFieldElementTest extends TestCase
 {
@@ -247,6 +249,110 @@ class MockFieldElementTest extends TestCase
     public function testItFailsIfFieldIsNotNotSortable()
     {
         $this->shouldFail()->mock->field('Delta')->assertNotSortable();
+    }
+
+    // endregion
+
+    // region assertShownOnIndex
+    public function testItSucceedsIfFieldIsShownOnIndexWithCallable()
+    {
+        $this->mock->field('Zeta')->assertShownOnIndex(request: LensRequest::createFromGlobals());
+    }
+
+    public function testItFailsIfFieldIsNotShownOnIndexWithCallable()
+    {
+        $this->shouldFail()->mock->field('Zeta')->assertShownOnIndex();
+    }
+
+    // endregion
+
+    // region assertHiddenFromIndex
+    public function testItSucceedsIfFieldIsHiddenFromIndexWithCallable()
+    {
+        $this->mock->field('Eta')->assertHiddenFromIndex(request: LensRequest::createFromGlobals());
+    }
+
+    public function testItFailsIfFieldIsNotHiddenFromIndexWithCallable()
+    {
+        $this->shouldFail()->mock->field('Eta')->assertHiddenFromIndex();
+    }
+
+    // endregion
+
+    // region assertShownOnDetail
+    public function testItSucceedsIfFieldIsShownOnDetailWithCallable()
+    {
+        $this->mock->field('Zeta')->assertShownOnDetail(request: LensRequest::createFromGlobals());
+    }
+
+    public function testItFailsIfFieldIsNotShownOnDetailWithCallable()
+    {
+        $this->shouldFail()->mock->field('Zeta')->assertShownOnDetail();
+    }
+
+    // endregion
+
+    // region assertHiddenFromDetail
+    public function testItSucceedsIfFieldIsHiddenFromDetailWithCallable()
+    {
+        $this->mock->field('Eta')->assertHiddenFromDetail(request: LensRequest::createFromGlobals());
+    }
+
+    public function testItFailsIfFieldIsNotHiddenFromDetailWithCallable()
+    {
+        $this->shouldFail()->mock->field('Eta')->assertHiddenFromDetail();
+    }
+
+    // endregion
+
+    // region assertShownWhenCreating
+    public function testItSucceedsIfFieldIsShownWhenCreatingWithCallable()
+    {
+        $this->mock->field('Zeta')->assertShownWhenCreating(request: LensRequest::createFromGlobals());
+    }
+
+    public function testItFailsIfFieldIsNotShownWhenCreatingWithCallable()
+    {
+        $this->shouldFail()->mock->field('Zeta')->assertShownWhenCreating();
+    }
+
+    // endregion
+
+    // region assertHiddenWhenCreating
+    public function testItSucceedsIfFieldIsHiddenWhenCreatingWithCallable()
+    {
+        $this->mock->field('Eta')->assertHiddenWhenCreating(request: LensRequest::createFromGlobals());
+    }
+
+    public function testItFailsIfFieldIsNotHiddenWhenCreatingWithCallable()
+    {
+        $this->shouldFail()->mock->field('Eta')->assertHiddenWhenCreating();
+    }
+
+    // endregion
+
+    // region assertShownWhenUpdating
+    public function testItSucceedsIfFieldIsShownWhenUpdatingWithCallable()
+    {
+        $this->mock->field('Zeta')->assertShownWhenUpdating(request: LensRequest::createFromGlobals());
+    }
+
+    public function testItFailsIfFieldIsNotShownWhenUpdatingWithCallable()
+    {
+        $this->shouldFail()->mock->field('Zeta')->assertShownWhenUpdating();
+    }
+
+    // endregion
+
+    // region assertHiddenWhenUpdating
+    public function testItSucceedsIfFieldIsHiddenWhenUpdatingWithCallable()
+    {
+        $this->mock->field('Eta')->assertHiddenWhenUpdating(request: LensRequest::createFromGlobals());
+    }
+
+    public function testItFailsIfFieldIsNotHiddenWhenUpdatingWithCallable()
+    {
+        $this->shouldFail()->mock->field('Eta')->assertHiddenWhenUpdating();
     }
 
     // endregion

--- a/tests/Feature/Traits/FieldAssertionsTest.php
+++ b/tests/Feature/Traits/FieldAssertionsTest.php
@@ -117,6 +117,35 @@ class FieldAssertionsTest extends TestCase
 
     // endregion
 
+    // region assertHasFields
+    public function testItSucceedsWhenSearchingForFieldsByName()
+    {
+        $mock = new MockAction(new ActionValidFields());
+        $mock->assertHasFields(['alpha', 'beta']);
+    }
+
+    public function testItSucceedsWhenSearchingForFieldsByAttribute()
+    {
+        $mock = new MockAction(new ActionValidFields());
+        $mock->assertHasFields(['field_alpha', 'field_beta']);
+    }
+
+    public function testItFailsWhenSearchingForFieldsByAttributeCaseSensitive()
+    {
+        $this->shouldFail();
+        $mock = new MockAction(new ActionValidFields());
+        $mock->assertHasFields(['Field_Alpha', 'Field_Beta']);
+    }
+
+    public function testItFailsWhenNoFieldsHasEitherNameOrAttributeGiven()
+    {
+        $this->shouldFail();
+        $mock = new MockAction(new ActionValidFields());
+        $mock->assertHasFields(['gamma']);
+    }
+
+    // endregion
+
     // region assertFieldMissing
     public function testItSucceedsWhenNoFieldMatchesByNameOrAttribute()
     {
@@ -142,6 +171,35 @@ class FieldAssertionsTest extends TestCase
         $this->shouldFail();
         $mock = new MockAction(new ActionValidFields());
         $mock->assertFieldMissing('alpha');
+    }
+
+    // endregion
+
+    // region assertFieldsMissing
+    public function testItSucceedsWhenNoFieldsMatchesByNameOrAttribute()
+    {
+        $mock = new MockAction(new ActionValidFields());
+        $mock->assertFieldsMissing(['gamma']);
+    }
+
+    public function testItSucceedsWhenFieldsDoesNotMatchAttributeExactCase()
+    {
+        $mock = new MockAction(new ActionValidFields());
+        $mock->assertFieldsMissing(['Field_Alpha', 'Field_Beta']);
+    }
+
+    public function testItFailsWhenFieldsMatchesAttribute()
+    {
+        $this->shouldFail();
+        $mock = new MockAction(new ActionValidFields());
+        $mock->assertFieldsMissing(['field_alpha', 'field_beta']);
+    }
+
+    public function testItFailsWhenFieldsMatchesName()
+    {
+        $this->shouldFail();
+        $mock = new MockAction(new ActionValidFields());
+        $mock->assertFieldsMissing(['alpha']);
     }
 
     // endregion

--- a/tests/Fixtures/Resources/ResourceForFieldTests.php
+++ b/tests/Fixtures/Resources/ResourceForFieldTests.php
@@ -28,6 +28,32 @@ class ResourceForFieldTests extends Resource
             Text::make('Epsilon', 'field_epsilon')
                 ->creationRules('min:8')
                 ->updateRules('min:16'),
+            Text::make('Zeta', 'field_zeta')
+                ->showOnIndex(function (NovaRequest $request): bool {
+                    return $request->isLensRequest();
+                })
+                ->showOnDetail(function (NovaRequest $request): bool {
+                    return $request->isLensRequest();
+                })
+                ->showOnCreating(function (NovaRequest $request): bool {
+                    return $request->isLensRequest();
+                })
+                ->showOnUpdating(function (NovaRequest $request): bool {
+                    return $request->isLensRequest();
+                }),
+            Text::make('Eta', 'field_eta')
+                ->hideFromIndex(function (NovaRequest $request): bool {
+                    return $request->isLensRequest();
+                })
+                ->hideFromDetail(function (NovaRequest $request): bool {
+                    return $request->isLensRequest();
+                })
+                ->hideWhenCreating(function (NovaRequest $request): bool {
+                    return $request->isLensRequest();
+                })
+                ->hideWhenUpdating(function (NovaRequest $request): bool {
+                    return $request->isLensRequest();
+                }),
         ];
     }
 


### PR DESCRIPTION
This PR back port some changes I made for my own purpose and want to be back upstream has it could be useful for other people, I hope :)

Please find the copilot PR description:

This pull request introduces several improvements to the Nova testing utilities, focusing on enhancing flexibility and correctness in field assertions and action response handling. The most significant changes are the addition of request-aware field assertion methods, expanded batch assertion capabilities, and improved test coverage for callable field visibility conditions.

**Field assertion improvements:**

* All field assertion methods in the `FieldAssertions` trait and `MockFieldElement` class now accept an optional `NovaRequest` and resource parameter, allowing more accurate and flexible testing of fields whose visibility depends on the request or resource context. (`src/Traits/FieldAssertions.php`, `src/Fields/MockFieldElement.php`)

* New batch assertion methods `assertHasFields` and `assertFieldsMissing` are added to the `FieldAssertions` trait, enabling checks for multiple fields at once. (`src/Traits/FieldAssertions.php`)

* The new private helper method `fieldsForComponent` in `FieldAssertions` ensures the correct fields are retrieved from a component, accounting for Nova's attribute filtering logic. (`src/Traits/FieldAssertions.php`)

**Action response and constraint updates:**

* The `MockActionResponse` and `IsActionResponseType` classes are simplified to remove array-based response structure checks, now focusing exclusively on `ActionResponse` instances for type assertions. (`src/Actions/MockActionResponse.php`, `src/Constraints/IsActionResponseType.php`)

**Test coverage enhancements:**

* Comprehensive tests have been added for all field visibility assertion methods, including cases where the field's visibility is determined by a callable, ensuring correct behavior when different request types are used. (`tests/Feature/Fields/MockFieldElementTest.php`)

These changes collectively make the Nova testing utilities more robust, flexible, and accurate for real-world Nova applications.

